### PR TITLE
Allow matching SHA256 fingerprint instead of SSH public key string

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,23 @@ t+aaaaafoOBaRRqTgPrs9pWUBKiOHw/EYq9lf1DSovogAAAAAAECAwQF
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOaaaafoOBaRRqTgPrs9pWUBKiOHw/EYq9lf1DSovog
 
 ```
+
+Find a public key whose SHA256 fingerprint starts with `0000`:
+```bash
+$ ./vanityssh --fingerprint --regex '^0000'
+global_user_input = ^0000
+Press Ctrl+C to end
+SSH Keys Processed = 7420830
+Total execution time 46.479848625s
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtz
+c2gtZWQyNTUxOQAAACCDaz0XpXwr1lXkMe9d/XiYhEqoEo7xND+WfIi6Rcpc9QAA
+AIiSMeGukjHhrgAAAAtzc2gtZWQyNTUxOQAAACCDaz0XpXwr1lXkMe9d/XiYhEqo
+Eo7xND+WfIi6Rcpc9QAAAEA2q7FROiORV1NCMmOFKpPuJC4PpkiqL8zOJKRjowbZ
+34NrPRelfCvWVeQx7139eJiESqgSjvE0P5Z8iLpFylz1AAAAAAECAwQF
+-----END OPENSSH PRIVATE KEY-----
+
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIINrPRelfCvWVeQx7139eJiESqgSjvE0P5Z8iLpFylz1
+SHA256:0000+RLM8XK4vFSKhEUKyvztCIFtR+Q7j04eKB3fA2c=
+
+```


### PR DESCRIPTION
GitHub now supports [SSH commit verification](https://github.blog/changelog/2022-08-23-ssh-commit-verification-now-supported/). However, the string that gets shown in the verified badge is the SHA256 fingerprint of the public key, not the public key itself.

This PR adds a `--fingerprint` flag to allow matching against the fingerprint instead.

![image](https://user-images.githubusercontent.com/193136/194283593-9c0d8a52-81c6-491a-a75f-204ae2beeda4.png)

p.s. I am participating in Hacktoberfest, so if you choose to accept this PR, it would be really great if you can also [add the `hacktoberfest-accepted` label to this PR](https://hacktoberfest.com/participation/#:~:text=YOUR%20PR/MRS%20MUST%20BE%20IN%20A%20REPO%20TAGGED%20WITH%20THE%20%E2%80%9CHACKTOBERFEST%E2%80%9D%20TOPIC%2C%20OR%20HAVE%20THE%20%E2%80%9CHACKTOBERFEST%2DACCEPTED%E2%80%9D%20LABEL.).