### PR TITLE
Add keys per second display

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 )
 
-require golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+require (
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a h1:eU8j/ClY2Ty3qdHnn0TyW3ivFoPC/0F1gQZz8yTxbbE=
 github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a/go.mod h1:v8eSC2SMp9/7FTKUncp7fH9IwPfw+ysMObcEz5FWheQ=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=

--- a/vanityssh.go
+++ b/vanityssh.go
@@ -120,14 +120,19 @@ func main() {
 
 	deleteLine := "\033[2K\r"
 	cursorUp := "\033[A"
+	prev_counter := global_counter
+	prev_time := time.Now()
 
 	for {
+		time.Sleep(250 * time.Millisecond)
+
+		relTime := time.Now().Sub(prev_time).Seconds()
+
 		fmt.Printf("%s%s%s", deleteLine, cursorUp, deleteLine)
 		fmt.Printf("SSH Keys Processed = %s\n", humanize.Comma(global_counter))
-		fmt.Printf("kKeys/s = %.2f",
-			(float64(global_counter) / time.Since(start).Seconds() / 1000))
-
-		time.Sleep(250 * time.Millisecond)
+		fmt.Printf("kKeys/s = %.2f", float64(global_counter-prev_counter)/relTime/1000)
+		prev_counter = global_counter
+		prev_time = time.Now()
 	}
 
 	WaitForCtrlC()

--- a/vanityssh.go
+++ b/vanityssh.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/mikesmitty/edkey"
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ssh"
@@ -122,9 +123,10 @@ func main() {
 
 	for {
 		fmt.Printf("%s%s%s", deleteLine, cursorUp, deleteLine)
-		fmt.Printf("SSH Keys Processed = %d\n", global_counter)
+		fmt.Printf("SSH Keys Processed = %s\n", humanize.Comma(global_counter))
 		fmt.Printf("kKeys/s = %.2f",
 			(float64(global_counter) / time.Since(start).Seconds() / 1000))
+
 		time.Sleep(250 * time.Millisecond)
 	}
 

--- a/vanityssh.go
+++ b/vanityssh.go
@@ -132,7 +132,7 @@ func main() {
 
 	for {
 		time.Sleep(250 * time.Millisecond)
-		relTime := time.Now().Sub(oldTime).Seconds()
+		relTime := time.Since(oldTime).Seconds()
 
 		// on first run, initialize the moving average with the current rate
 		// instead of starting at 0 and taking many seconds to tend towards the

--- a/vanityssh.go
+++ b/vanityssh.go
@@ -26,7 +26,7 @@ var global_user_insensitive bool
 var global_user_streaming bool
 var global_user_fingerprint bool
 
-//var flagvar int
+// var flagvar int
 var global_counter int64
 var start time.Time
 var re *regexp.Regexp
@@ -116,8 +116,15 @@ func main() {
 	}
 
 	fmt.Printf("Press Ctrl+C to end\n")
+
+	deleteLine := "\033[2K\r"
+	cursorUp := "\033[A"
+
 	for {
-		fmt.Printf("\033[2K\r%s%d", "SSH Keys Processed = ", global_counter)
+		fmt.Printf("%s%s%s", deleteLine, cursorUp, deleteLine)
+		fmt.Printf("SSH Keys Processed = %d\n", global_counter)
+		fmt.Printf("kKeys/s = %.2f",
+			(float64(global_counter) / time.Since(start).Seconds() / 1000))
 		time.Sleep(250 * time.Millisecond)
 	}
 


### PR DESCRIPTION
This PR adds a display of the live keys/second.

In the second commit, I pull in [a library](https://pkg.go.dev/github.com/dustin/go-humanize) to add commas into the `global_counter` display, if you don't want to add a dependency just for this i'm happy to get this merged without that commit!