### PR TITLE
refactor: harden display/keygen packages and simplify test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix data race on `isTTY` flag by converting to `atomic.Bool`
+- Fix `Reset()` writing to stderr without holding the display mutex
+- Fix `UpdateStatusBar` writing ANSI escapes in non-TTY environments
+- Fix `FormatCount` for negative numbers and `math.MinInt64` overflow
+- Clamp terminal height to minimum 3 to prevent invalid ANSI sequences
+- Reject negative `--jobs` values that caused the program to hang
+- Return `ErrNilRegex` from `FindKeys` instead of panicking on nil regex
+- Fix `OverrideTTY` data race on `termHeight` (CC-3: missing mutex)
+- Fix `--continuous` in TTY mode silently discarding matched keys
+
+### Tests
+
+- Add `cmd` test suite: CLI validation, `handleResult` file writing and
+  permissions, TTY/non-TTY output paths, write-error propagation, flag
+  wiring, end-to-end pipeline
+- Add `display` TTY-mode tests, concurrency stress tests, and edge cases
+- Add `keygen` tests: cancellation, blocked-send, selective regex, concurrent
+  workers, hot-path/slow-path equivalence, fingerprint-mode isolation
+
 ### Added
 
 - Context-based goroutine lifecycle with `errgroup` for clean shutdown
 - `keygen.Result` type — `FindKeys` is now a pure worker sending results via channel
 - Error handling for all key generation operations (no silent suppression)
-- Test suite for `display` (FormatCount, IsTTY) and `keygen` (helpers + FindKeys)
 - Homebrew tap via GoReleaser (`brew install sensiblebit/tap/vanityssh`)
 - Cobra CLI rewrite with `--fingerprint`, `--continuous`, `--jobs` flags
 - Pinned terminal status bar with scroll region for TTY output
@@ -22,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pre-commit hooks (branch naming, commit messages, go-vet, go-build, go-test)
 - Dependabot for GitHub Actions and Go module updates
 - Makefile with build, test, vet targets
+- Export `ErrNilRegex` sentinel error for programmatic nil-regex detection
+  via `errors.Is`
 - CHANGELOG.md
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,7 @@ Every PR runs parallel checks via reusable workflows
 (`.github/workflows/ci.yml`):
 
 | Check | What it validates |
-|---|---|
+| --- | --- |
 | PR Conventions | PR title, branch name, commit messages, verified commits |
 | Go CI | `go build`, `go vet`, goimports, `go test -race -count=1 ./...` |
 | Lint | golangci-lint (errcheck, staticcheck, unused, etc.), govulncheck, markdownlint |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,9 @@ func run(_ *cobra.Command, args []string) error {
 	}()
 
 	numJobs := flagJobs
+	if numJobs < 0 {
+		return fmt.Errorf("--jobs must be non-negative, got %d", numJobs)
+	}
 	if numJobs == 0 {
 		numJobs = runtime.NumCPU()
 	}
@@ -154,7 +157,7 @@ func handleResult(r keygen.Result) error {
 		display.PrintAboveStatus("SHA256:%s", r.Fingerprint)
 	}
 
-	if !display.IsTTY() && flagContinuous {
+	if flagContinuous {
 		fmt.Printf("%s", r.PrivateKeyPEM)
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,550 @@
+// Tests in this file mutate process-global state (os.Stdout, os.Chdir,
+// package-level flag variables) and must NOT use t.Parallel().
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/danielewood/vanityssh-go/display"
+	"github.com/danielewood/vanityssh-go/keygen"
+)
+
+// captureStdout redirects os.Stdout to a pipe, calls fn, then returns
+// everything written to stdout. Must not be called concurrently.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe writer: %v", err)
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("closing pipe reader: %v", err)
+	}
+	return string(data)
+}
+
+// captureStderr redirects os.Stderr to a pipe, calls fn, then returns
+// everything written to stderr. Must not be called concurrently.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	origStderr := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe writer: %v", err)
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("closing pipe reader: %v", err)
+	}
+	return string(data)
+}
+
+// fakeResult returns a minimal valid keygen.Result for testing.
+func fakeResult(t *testing.T) keygen.Result {
+	t.Helper()
+	return keygen.Result{
+		PrivateKeyPEM: []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----\n"),
+		AuthorizedKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKey",
+		Fingerprint:   "dGVzdA==",
+	}
+}
+
+// saveFlags saves the current flag values and restores them on cleanup.
+func saveFlags(t *testing.T) {
+	t.Helper()
+	origFingerprint := flagFingerprint
+	origContinuous := flagContinuous
+	origJobs := flagJobs
+	t.Cleanup(func() {
+		flagFingerprint = origFingerprint
+		flagContinuous = origContinuous
+		flagJobs = origJobs
+		rootCmd.SetArgs(nil)
+	})
+}
+
+// chdirTemp changes to a temp directory and restores on cleanup.
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Fatalf("Chdir restore: %v", err)
+		}
+	})
+	return dir
+}
+
+func TestRun_InvalidRegex(t *testing.T) {
+	saveFlags(t)
+	rootCmd.SetArgs([]string{"[invalid"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid regex") {
+		t.Errorf("error = %q, want substring %q", err, "invalid regex")
+	}
+}
+
+func TestRun_NegativeJobs(t *testing.T) {
+	saveFlags(t)
+	rootCmd.SetArgs([]string{"--jobs", "-1", "."})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--jobs must be non-negative") {
+		t.Errorf("error = %q, want substring %q", err, "--jobs must be non-negative")
+	}
+}
+
+func TestRun_WrongArgCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantSub string
+	}{
+		{name: "zero args", args: []string{}, wantSub: "accepts 1 arg(s)"},
+		{name: "two args", args: []string{"foo", "bar"}, wantSub: "accepts 1 arg(s)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saveFlags(t)
+			rootCmd.SetArgs(tt.args)
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error = %q, want substring %q", err, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestRun_JobsZeroAccepted(t *testing.T) {
+	saveFlags(t)
+	// Invalid regex exits early after flag validation.
+	rootCmd.SetArgs([]string{"--jobs", "0", "[invalid"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Error should be about regex, not --jobs.
+	if !strings.Contains(err.Error(), "invalid regex") {
+		t.Errorf("error = %q, want substring %q (--jobs 0 should be accepted)", err, "invalid regex")
+	}
+}
+
+func TestHandleResult_NonTTY_SingleMode(t *testing.T) {
+	dir := chdirTemp(t)
+	saveFlags(t)
+	flagContinuous = false
+
+	r := fakeResult(t)
+	got := captureStdout(t, func() {
+		if err := handleResult(r); err != nil {
+			t.Fatalf("handleResult: %v", err)
+		}
+	})
+
+	if got != string(r.PrivateKeyPEM) {
+		t.Errorf("stdout = %q, want PEM", got)
+	}
+
+	// Private key file: exists, 0600.
+	info, err := os.Stat(filepath.Join(dir, "id_ed25519"))
+	if err != nil {
+		t.Fatalf("private key file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("private key permissions = %o, want 0600", perm)
+	}
+
+	// Public key file: exists, 0644.
+	info, err = os.Stat(filepath.Join(dir, "id_ed25519.pub"))
+	if err != nil {
+		t.Fatalf("public key file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0644 {
+		t.Errorf("public key permissions = %o, want 0644", perm)
+	}
+}
+
+func TestHandleResult_NonTTY_ContinuousMode(t *testing.T) {
+	dir := chdirTemp(t)
+	saveFlags(t)
+	flagContinuous = true
+
+	r := fakeResult(t)
+	got := captureStdout(t, func() {
+		if err := handleResult(r); err != nil {
+			t.Fatalf("handleResult: %v", err)
+		}
+	})
+
+	if got != string(r.PrivateKeyPEM) {
+		t.Errorf("stdout = %q, want PEM", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "id_ed25519")); err == nil {
+		t.Error("private key file should not exist in continuous mode")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "id_ed25519.pub")); err == nil {
+		t.Error("public key file should not exist in continuous mode")
+	}
+}
+
+func TestHandleResult_WriteError_PrivateKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based permission test not supported on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root")
+	}
+
+	dir := filepath.Join(t.TempDir(), "nonexistent")
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Fatalf("Chdir restore: %v", err)
+		}
+	})
+
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(dir, 0755); err != nil {
+			t.Errorf("restoring dir permissions: %v", err)
+		}
+	})
+
+	saveFlags(t)
+	flagContinuous = false
+
+	r := fakeResult(t)
+	got := captureStdout(t, func() {
+		err := handleResult(r)
+		if err == nil {
+			t.Fatal("expected write error, got nil")
+		}
+		if !strings.Contains(err.Error(), "write private key") {
+			t.Errorf("error = %q, want substring %q", err, "write private key")
+		}
+	})
+
+	// PEM must still be on stdout even though file write failed.
+	if got != string(r.PrivateKeyPEM) {
+		t.Errorf("stdout = %q, want PEM preserved on write error", got)
+	}
+}
+
+func TestHandleResult_WriteError_PublicKey(t *testing.T) {
+	dir := chdirTemp(t)
+
+	// Pre-create id_ed25519.pub as a directory so write fails.
+	if err := os.Mkdir(filepath.Join(dir, "id_ed25519.pub"), 0755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	saveFlags(t)
+	flagContinuous = false
+
+	r := fakeResult(t)
+	captureStdout(t, func() {
+		err := handleResult(r)
+		if err == nil {
+			t.Fatal("expected write error, got nil")
+		}
+		if !strings.Contains(err.Error(), "write public key") {
+			t.Errorf("error = %q, want substring %q", err, "write public key")
+		}
+	})
+}
+
+func TestRun_EndToEnd(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "public key mode", args: []string{"--jobs", "1", "."}},
+		{name: "fingerprint mode", args: []string{"--fingerprint", "--jobs", "1", "."}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := chdirTemp(t)
+			saveFlags(t)
+			keygen.ResetCounters()
+			t.Cleanup(func() { keygen.ResetCounters() })
+
+			rootCmd.SetArgs(tt.args)
+
+			got := captureStdout(t, func() {
+				if err := rootCmd.Execute(); err != nil {
+					t.Fatalf("Execute error: %v", err)
+				}
+			})
+
+			if !strings.Contains(got, "-----BEGIN OPENSSH PRIVATE KEY-----") {
+				t.Error("stdout missing PEM header")
+			}
+
+			// Key files must exist with correct permissions.
+			privInfo, err := os.Stat(filepath.Join(dir, "id_ed25519"))
+			if err != nil {
+				t.Fatalf("private key file: %v", err)
+			}
+			if perm := privInfo.Mode().Perm(); perm != 0600 {
+				t.Errorf("private key permissions = %o, want 0600", perm)
+			}
+
+			pubInfo, err := os.Stat(filepath.Join(dir, "id_ed25519.pub"))
+			if err != nil {
+				t.Fatalf("public key file: %v", err)
+			}
+			if perm := pubInfo.Mode().Perm(); perm != 0644 {
+				t.Errorf("public key permissions = %o, want 0644", perm)
+			}
+
+			pubData, err := os.ReadFile(filepath.Join(dir, "id_ed25519.pub"))
+			if err != nil {
+				t.Fatalf("read public key: %v", err)
+			}
+			if !strings.HasPrefix(string(pubData), "ssh-ed25519 ") {
+				t.Errorf("public key = %q, want prefix %q", pubData, "ssh-ed25519 ")
+			}
+
+			if keygen.KeyCount() == 0 {
+				t.Error("KeyCount() = 0, want > 0")
+			}
+			if keygen.MatchCount() < 1 {
+				t.Errorf("MatchCount() = %d, want >= 1", keygen.MatchCount())
+			}
+		})
+	}
+}
+
+func TestRun_FlagWiring(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		check func(t *testing.T)
+	}{
+		{
+			name: "long --jobs",
+			args: []string{"--jobs", "3", "[invalid"},
+			check: func(t *testing.T) {
+				t.Helper()
+				if flagJobs != 3 {
+					t.Errorf("flagJobs = %d, want 3", flagJobs)
+				}
+			},
+		},
+		{
+			name: "short -j",
+			args: []string{"-j", "5", "[invalid"},
+			check: func(t *testing.T) {
+				t.Helper()
+				if flagJobs != 5 {
+					t.Errorf("flagJobs = %d, want 5", flagJobs)
+				}
+			},
+		},
+		{
+			name: "long --fingerprint",
+			args: []string{"--fingerprint", "[invalid"},
+			check: func(t *testing.T) {
+				t.Helper()
+				if !flagFingerprint {
+					t.Error("flagFingerprint = false, want true")
+				}
+			},
+		},
+		{
+			name: "short -f",
+			args: []string{"-f", "[invalid"},
+			check: func(t *testing.T) {
+				t.Helper()
+				if !flagFingerprint {
+					t.Error("flagFingerprint = false, want true")
+				}
+			},
+		},
+		{
+			name: "long --continuous",
+			args: []string{"--continuous", "[invalid"},
+			check: func(t *testing.T) {
+				t.Helper()
+				if !flagContinuous {
+					t.Error("flagContinuous = false, want true")
+				}
+			},
+		},
+		{
+			name: "short -c",
+			args: []string{"-c", "[invalid"},
+			check: func(t *testing.T) {
+				t.Helper()
+				if !flagContinuous {
+					t.Error("flagContinuous = false, want true")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saveFlags(t)
+			rootCmd.SetArgs(tt.args)
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "invalid regex") {
+				t.Errorf("error = %q, want substring %q", err, "invalid regex")
+			}
+			tt.check(t)
+		})
+	}
+}
+
+func TestHandleResult_TTY_SingleMode(t *testing.T) {
+	dir := chdirTemp(t)
+	saveFlags(t)
+	flagContinuous = false
+
+	restore := display.OverrideTTY(true, 24)
+	t.Cleanup(restore)
+
+	r := fakeResult(t)
+
+	var stdoutGot string
+	stderrGot := captureStderr(t, func() {
+		stdoutGot = captureStdout(t, func() {
+			if err := handleResult(r); err != nil {
+				t.Fatalf("handleResult: %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(stdoutGot, string(r.PrivateKeyPEM)) {
+		t.Error("stdout missing PEM")
+	}
+	if !strings.Contains(stdoutGot, r.AuthorizedKey) {
+		t.Error("stdout missing authorized key")
+	}
+	if !strings.Contains(stderrGot, "Match #") {
+		t.Error("stderr missing match header")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "id_ed25519")); err != nil {
+		t.Fatalf("private key file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "id_ed25519.pub")); err != nil {
+		t.Fatalf("public key file: %v", err)
+	}
+}
+
+func TestHandleResult_TTY_ContinuousMode(t *testing.T) {
+	dir := chdirTemp(t)
+	saveFlags(t)
+	flagContinuous = true
+
+	restore := display.OverrideTTY(true, 24)
+	t.Cleanup(restore)
+
+	r := fakeResult(t)
+
+	var stdoutGot string
+	stderrGot := captureStderr(t, func() {
+		stdoutGot = captureStdout(t, func() {
+			if err := handleResult(r); err != nil {
+				t.Fatalf("handleResult: %v", err)
+			}
+		})
+	})
+
+	if stdoutGot != string(r.PrivateKeyPEM) {
+		t.Errorf("stdout = %q, want PEM", stdoutGot)
+	}
+	if !strings.Contains(stderrGot, "Match #") {
+		t.Error("stderr missing match header")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "id_ed25519")); err == nil {
+		t.Error("private key file should not exist in continuous mode")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "id_ed25519.pub")); err == nil {
+		t.Error("public key file should not exist in continuous mode")
+	}
+}
+
+func TestSetVersion_VersionFlag(t *testing.T) {
+	saveFlags(t)
+	SetVersion("test-v1.2.3")
+	t.Cleanup(func() { rootCmd.Version = "" })
+
+	rootCmd.SetArgs([]string{"--version"})
+
+	got := captureStdout(t, func() {
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute with --version: %v", err)
+		}
+	})
+
+	if !strings.Contains(got, "test-v1.2.3") {
+		t.Errorf("output = %q, want substring %q", got, "test-v1.2.3")
+	}
+}

--- a/display/display.go
+++ b/display/display.go
@@ -2,8 +2,10 @@ package display
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/term"
 )
@@ -11,31 +13,60 @@ import (
 var (
 	mu         sync.Mutex
 	termHeight int
-	isTTY      bool
+	ttyFlag    atomic.Bool
 )
 
 // Init detects the terminal and sets up the scroll region if interactive.
 func Init() {
-	isTTY = term.IsTerminal(int(os.Stdout.Fd()))
-	if !isTTY {
+	tty := term.IsTerminal(int(os.Stdout.Fd()))
+	ttyFlag.Store(tty)
+	if !tty {
 		return
 	}
 	_, h, err := term.GetSize(int(os.Stderr.Fd()))
+
+	mu.Lock()
+	defer mu.Unlock()
 	if err != nil {
 		termHeight = 24
 	} else {
 		termHeight = h
+	}
+	// ANSI row numbers are 1-indexed and we need at least a content row
+	// and a status row. Clamp to minimum 3 to prevent invalid sequences.
+	if termHeight < 3 {
+		termHeight = 3
 	}
 	fmt.Fprintf(os.Stderr, "\033[1;%dr", termHeight-1)
 	fmt.Fprintf(os.Stderr, "\033[%d;1H", termHeight-1)
 }
 
 // IsTTY returns whether stdout is a terminal.
-func IsTTY() bool { return isTTY }
+func IsTTY() bool { return ttyFlag.Load() }
+
+// OverrideTTY overrides the TTY state for testing. It sets the ttyFlag and
+// termHeight, returning a function that restores the original values.
+// This must only be called from tests.
+func OverrideTTY(tty bool, height int) func() {
+	mu.Lock()
+	origTTY := ttyFlag.Load()
+	origHeight := termHeight
+	ttyFlag.Store(tty)
+	termHeight = height
+	mu.Unlock()
+	return func() {
+		mu.Lock()
+		ttyFlag.Store(origTTY)
+		termHeight = origHeight
+		mu.Unlock()
+	}
+}
 
 // Reset restores the terminal scroll region.
 func Reset() {
-	if !isTTY {
+	mu.Lock()
+	defer mu.Unlock()
+	if !ttyFlag.Load() {
 		return
 	}
 	fmt.Fprintf(os.Stderr, "\033[r")
@@ -46,7 +77,7 @@ func Reset() {
 func PrintAboveStatus(format string, args ...any) {
 	mu.Lock()
 	defer mu.Unlock()
-	if !isTTY {
+	if !ttyFlag.Load() {
 		fmt.Fprintf(os.Stderr, format+"\n", args...)
 		return
 	}
@@ -63,6 +94,9 @@ func PrintAboveStatus(format string, args ...any) {
 func UpdateStatusBar(status string) {
 	mu.Lock()
 	defer mu.Unlock()
+	if !ttyFlag.Load() {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "\033[s")
 	fmt.Fprintf(os.Stderr, "\033[%d;1H", termHeight)
 	fmt.Fprintf(os.Stderr, "\033[2K")
@@ -72,6 +106,14 @@ func UpdateStatusBar(status string) {
 
 // FormatCount formats an integer with comma separators.
 func FormatCount(n int64) string {
+	if n < 0 {
+		if n == math.MinInt64 {
+			// -math.MinInt64 overflows int64; handle by formatting
+			// the positive portion after separating the sign.
+			return "-9,223,372,036,854,775,808"
+		}
+		return "-" + FormatCount(-n)
+	}
 	if n < 1000 {
 		return fmt.Sprintf("%d", n)
 	}

--- a/display/display_test.go
+++ b/display/display_test.go
@@ -1,29 +1,84 @@
 package display
 
-import "testing"
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// setTTY overrides the ttyFlag and termHeight for testing and registers a
+// cleanup function via t.Cleanup to restore the original values. Must be
+// called from non-parallel tests.
+func setTTY(t *testing.T, tty bool, height int) {
+	t.Helper()
+	mu.Lock()
+	origTTY := ttyFlag.Load()
+	origHeight := termHeight
+	ttyFlag.Store(tty)
+	termHeight = height
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		ttyFlag.Store(origTTY)
+		termHeight = origHeight
+		mu.Unlock()
+	})
+}
+
+// captureStderr redirects os.Stderr to a pipe, calls fn, then returns
+// everything written to stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	origStderr := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe writer: %v", err)
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("closing pipe reader: %v", err)
+	}
+	return string(data)
+}
 
 func TestFormatCount(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
 		n    int64
 		want string
 	}{
-		{name: "zero", n: 0, want: "0"},
-		{name: "single digit", n: 7, want: "7"},
-		{name: "below threshold", n: 999, want: "999"},
-		{name: "at threshold", n: 1000, want: "1,000"},
-		{name: "five digits", n: 12345, want: "12,345"},
-		{name: "millions", n: 1234567, want: "1,234,567"},
-		{name: "billions", n: 1234567890, want: "1,234,567,890"},
+		{0, "0"},
+		{999, "999"},
+		{1000, "1,000"},
+		{12345, "12,345"},
+		{1234567, "1,234,567"},
+		{-1, "-1"},
+		{-1234, "-1,234"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", tt.n), func(t *testing.T) {
 			t.Parallel()
-			got := FormatCount(tt.n)
-			if got != tt.want {
+			if got := FormatCount(tt.n); got != tt.want {
 				t.Errorf("FormatCount(%d) = %q, want %q", tt.n, got, tt.want)
 			}
 		})
@@ -31,10 +86,227 @@ func TestFormatCount(t *testing.T) {
 }
 
 func TestIsTTY(t *testing.T) {
-	t.Parallel()
+	// Not parallel: modifies package-level state via setTTY.
 
-	// In test environment, stdout is not a terminal
 	if IsTTY() {
 		t.Error("IsTTY() = true in test environment, want false")
+	}
+
+	setTTY(t, true, 24)
+	if !IsTTY() {
+		t.Error("IsTTY() = false after setTTY(true), want true")
+	}
+}
+
+func TestInit_NonTTY(t *testing.T) {
+	// Not parallel: modifies package-level state.
+
+	origTTY := ttyFlag.Load()
+	origHeight := termHeight
+	t.Cleanup(func() {
+		ttyFlag.Store(origTTY)
+		termHeight = origHeight
+	})
+
+	got := captureStderr(t, func() { Init() })
+
+	if IsTTY() {
+		t.Error("IsTTY() = true after Init() in test, want false")
+	}
+	if got != "" {
+		t.Errorf("Init() non-TTY output = %q, want empty", got)
+	}
+}
+
+func TestReset_NonTTY(t *testing.T) {
+	// Not parallel: depends on package-level state.
+
+	got := captureStderr(t, func() { Reset() })
+	if got != "" {
+		t.Errorf("Reset() non-TTY output = %q, want empty", got)
+	}
+}
+
+func TestPrintAboveStatus_NonTTY(t *testing.T) {
+	// Not parallel: redirects os.Stderr.
+
+	got := captureStderr(t, func() {
+		PrintAboveStatus("test: %s", "hello")
+	})
+
+	if got != "test: hello\n" {
+		t.Errorf("output = %q, want %q", got, "test: hello\n")
+	}
+	if strings.Contains(got, "\033[") {
+		t.Errorf("non-TTY output contains ANSI escapes: %q", got)
+	}
+}
+
+func TestUpdateStatusBar_NonTTY(t *testing.T) {
+	// Not parallel: depends on package-level state.
+
+	got := captureStderr(t, func() {
+		UpdateStatusBar("test status")
+	})
+	if got != "" {
+		t.Errorf("UpdateStatusBar non-TTY output = %q, want empty", got)
+	}
+}
+
+func TestPrintAboveStatus_TTY(t *testing.T) {
+	// Not parallel: modifies package-level state and redirects os.Stderr.
+
+	setTTY(t, true, 24)
+
+	got := captureStderr(t, func() {
+		PrintAboveStatus("found key: %s", "abc123")
+	})
+
+	if !strings.Contains(got, "\033[s") {
+		t.Error("missing cursor save")
+	}
+	if !strings.Contains(got, "\033[u") {
+		t.Error("missing cursor restore")
+	}
+	if !strings.Contains(got, "found key: abc123") {
+		t.Error("missing content")
+	}
+	if !strings.Contains(got, "\033[2K") {
+		t.Error("missing line clear")
+	}
+	if saves, restores := strings.Count(got, "\033[s"), strings.Count(got, "\033[u"); saves != restores {
+		t.Errorf("unbalanced: %d saves vs %d restores", saves, restores)
+	}
+}
+
+func TestUpdateStatusBar_TTY(t *testing.T) {
+	// Not parallel: modifies package-level state and redirects os.Stderr.
+
+	setTTY(t, true, 24)
+
+	got := captureStderr(t, func() {
+		UpdateStatusBar("Keys: 1,000")
+	})
+
+	if !strings.Contains(got, "\033[s") {
+		t.Error("missing cursor save")
+	}
+	if !strings.Contains(got, "\033[u") {
+		t.Error("missing cursor restore")
+	}
+	if !strings.Contains(got, "\033[7m Keys: 1,000 \033[0m") {
+		t.Errorf("missing reverse-video content in %q", got)
+	}
+	if saves, restores := strings.Count(got, "\033[s"), strings.Count(got, "\033[u"); saves != restores {
+		t.Errorf("unbalanced: %d saves vs %d restores", saves, restores)
+	}
+}
+
+func TestReset_TTY(t *testing.T) {
+	// Not parallel: modifies package-level state and redirects os.Stderr.
+
+	setTTY(t, true, 24)
+
+	got := captureStderr(t, func() { Reset() })
+
+	if !strings.Contains(got, "\033[r") {
+		t.Error("missing scroll region reset")
+	}
+	if !strings.Contains(got, fmt.Sprintf("\033[%d;1H\n", 24)) {
+		t.Error("missing cursor reposition")
+	}
+}
+
+func TestPrintAboveStatus_Concurrent_NonTTY(t *testing.T) {
+	// Not parallel: redirects os.Stderr.
+
+	const goroutines = 10
+	const iterations = 50
+
+	got := captureStderr(t, func() {
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := range goroutines {
+			go func() {
+				defer wg.Done()
+				for j := range iterations {
+					PrintAboveStatus("worker %d iter %d", i, j)
+				}
+			}()
+		}
+		wg.Wait()
+	})
+
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+	if len(lines) != goroutines*iterations {
+		t.Errorf("got %d lines, want %d", len(lines), goroutines*iterations)
+	}
+	lineRe := regexp.MustCompile(`^worker \d+ iter \d+$`)
+	for i, line := range lines {
+		if !lineRe.MatchString(line) {
+			t.Errorf("line %d corrupted: %q", i, line)
+		}
+	}
+}
+
+func TestReset_Concurrent_TTY(t *testing.T) {
+	// Not parallel: modifies package-level state and redirects os.Stderr.
+
+	setTTY(t, true, 24)
+
+	// Test passes if no race or panic occurs (run with -race).
+	captureStderr(t, func() {
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				PrintAboveStatus("msg %d", 1)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				UpdateStatusBar("status")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				Reset()
+			}
+		}()
+		wg.Wait()
+	})
+}
+
+func TestPrintAboveStatus_EmptyFormat(t *testing.T) {
+	// Not parallel: redirects os.Stderr.
+
+	got := captureStderr(t, func() { PrintAboveStatus("") })
+	if got != "\n" {
+		t.Errorf("output = %q, want %q", got, "\n")
+	}
+}
+
+func TestPrintAboveStatus_FormatDirectivesInContent(t *testing.T) {
+	// Not parallel: redirects os.Stderr.
+
+	got := captureStderr(t, func() {
+		PrintAboveStatus("rate: %s", "50% complete")
+	})
+	if got != "rate: 50% complete\n" {
+		t.Errorf("output = %q, want %q", got, "rate: 50% complete\n")
+	}
+}
+
+func TestUpdateStatusBar_EmptyString(t *testing.T) {
+	// Not parallel: modifies package-level state and redirects os.Stderr.
+
+	setTTY(t, true, 24)
+
+	got := captureStderr(t, func() { UpdateStatusBar("") })
+	if got == "" {
+		t.Error("produced no output in TTY mode")
 	}
 }

--- a/keygen/keygen.go
+++ b/keygen/keygen.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -21,6 +22,9 @@ const pubKeyOffset = 19
 
 var globalCounter atomic.Int64
 var matchCounter atomic.Int64
+
+// ErrNilRegex is returned when FindKeys is called with a nil regex.
+var ErrNilRegex = errors.New("regex must not be nil")
 
 // Result holds a matched key pair and its metadata.
 type Result struct {
@@ -71,6 +75,9 @@ func getAuthorizedKey(key ssh.PublicKey) string {
 // Matched keys are sent on the results channel. Returns nil on context
 // cancellation, or an error if key generation fails.
 func FindKeys(ctx context.Context, opts Options, results chan<- Result) error {
+	if opts.Regex == nil {
+		return ErrNilRegex
+	}
 	wireKey := newWireKeyBuf()
 
 	authKeyPrefix := []byte("ssh-ed25519 ")

--- a/keygen/keygen_test.go
+++ b/keygen/keygen_test.go
@@ -1,9 +1,15 @@
+// Tests that read or write the global counters (KeyCount, MatchCount,
+// ResetCounters) must NOT be marked t.Parallel() — they share package-level
+// atomic state. Adding t.Parallel() to such tests will introduce races.
 package keygen
 
 import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
 	"regexp"
 	"strings"
 	"testing"
@@ -12,195 +18,392 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// assertResultFields checks that a keygen.Result has all fields populated
+// with correct prefixes. Does not re-validate stdlib crypto.
+func assertResultFields(t *testing.T, r Result) {
+	t.Helper()
+	if len(r.PrivateKeyPEM) == 0 {
+		t.Error("PrivateKeyPEM is empty")
+	}
+	if !strings.Contains(string(r.PrivateKeyPEM), "BEGIN OPENSSH PRIVATE KEY") {
+		t.Error("PrivateKeyPEM missing PEM header")
+	}
+	if !strings.HasPrefix(r.AuthorizedKey, "ssh-ed25519 ") {
+		t.Errorf("AuthorizedKey = %q, want prefix %q", r.AuthorizedKey, "ssh-ed25519 ")
+	}
+	if r.Fingerprint == "" {
+		t.Error("Fingerprint is empty")
+	}
+}
+
 func TestNewWireKeyBuf(t *testing.T) {
 	t.Parallel()
 
 	buf := newWireKeyBuf()
 
 	if len(buf) != wireKeyLen {
-		t.Errorf("newWireKeyBuf() length = %d, want %d", len(buf), wireKeyLen)
+		t.Errorf("length = %d, want %d", len(buf), wireKeyLen)
 	}
-
-	// Algorithm name length: big-endian uint32(11)
-	if buf[3] != 11 {
-		t.Errorf("algo name length byte = %d, want 11", buf[3])
+	if buf[0] != 0 || buf[1] != 0 || buf[2] != 0 || buf[3] != 11 {
+		t.Errorf("algo name length = [%d %d %d %d], want [0 0 0 11]",
+			buf[0], buf[1], buf[2], buf[3])
 	}
-
-	// Algorithm name
-	algoName := string(buf[4:15])
-	if algoName != "ssh-ed25519" {
-		t.Errorf("algo name = %q, want %q", algoName, "ssh-ed25519")
+	if string(buf[4:15]) != "ssh-ed25519" {
+		t.Errorf("algo name = %q, want %q", string(buf[4:15]), "ssh-ed25519")
 	}
-
-	// Public key length: big-endian uint32(32)
-	if buf[18] != 32 {
-		t.Errorf("key length byte = %d, want 32", buf[18])
+	if buf[15] != 0 || buf[16] != 0 || buf[17] != 0 || buf[18] != 32 {
+		t.Errorf("key length = [%d %d %d %d], want [0 0 0 32]",
+			buf[15], buf[16], buf[17], buf[18])
 	}
-}
-
-func TestGetFingerprint(t *testing.T) {
-	t.Parallel()
-
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("GenerateKey: %v", err)
-	}
-
-	sshPub, err := ssh.NewPublicKey(pub)
-	if err != nil {
-		t.Fatalf("NewPublicKey: %v", err)
-	}
-
-	fp := getFingerprint(sshPub)
-
-	if fp == "" {
-		t.Error("getFingerprint() returned empty string")
-	}
-
-	// SHA256 (32 bytes) base64-encoded = 44 chars
-	if len(fp) != 44 {
-		t.Errorf("getFingerprint() length = %d, want 44", len(fp))
+	for i := pubKeyOffset; i < wireKeyLen; i++ {
+		if buf[i] != 0 {
+			t.Errorf("buf[%d] = %d, want 0 (public key slot should be zeroed)", i, buf[i])
+			break
+		}
 	}
 }
 
-func TestGetAuthorizedKey(t *testing.T) {
+func TestNewWireKeyBuf_IndependentBuffers(t *testing.T) {
 	t.Parallel()
 
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("GenerateKey: %v", err)
+	buf1 := newWireKeyBuf()
+	buf2 := newWireKeyBuf()
+
+	for i := range buf1 {
+		buf1[i] = 0xFF
 	}
-
-	sshPub, err := ssh.NewPublicKey(pub)
-	if err != nil {
-		t.Fatalf("NewPublicKey: %v", err)
-	}
-
-	authKey := getAuthorizedKey(sshPub)
-
-	if authKey == "" {
-		t.Error("getAuthorizedKey() returned empty string")
-	}
-
-	if !strings.HasPrefix(authKey, "ssh-ed25519 ") {
-		t.Errorf("getAuthorizedKey() = %q, want prefix %q", authKey, "ssh-ed25519 ")
+	if buf2[3] != 11 {
+		t.Fatal("buffers share memory")
 	}
 }
 
-func TestFindKeysMatchesPublicKey(t *testing.T) {
+func TestHotPathSlowPathEquivalence(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	for range 10 {
+		pub, _, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("GenerateKey: %v", err)
+		}
+		sshPub, err := ssh.NewPublicKey(pub)
+		if err != nil {
+			t.Fatalf("NewPublicKey: %v", err)
+		}
 
-	// Match any ssh-ed25519 key (every key matches)
-	re := regexp.MustCompile(`ssh-ed25519`)
+		wireKey := newWireKeyBuf()
+		copy(wireKey[pubKeyOffset:], pub)
+
+		// Public key: hot path vs getAuthorizedKey.
+		authKeyPrefix := []byte("ssh-ed25519 ")
+		b64Len := base64.StdEncoding.EncodedLen(wireKeyLen)
+		authKeyBuf := make([]byte, len(authKeyPrefix)+b64Len)
+		copy(authKeyBuf, authKeyPrefix)
+		base64.StdEncoding.Encode(authKeyBuf[len(authKeyPrefix):], wireKey)
+		if got, want := string(authKeyBuf), getAuthorizedKey(sshPub); got != want {
+			t.Errorf("public key hot path %q != slow path %q", got, want)
+		}
+
+		// Fingerprint: hot path vs getFingerprint.
+		sum := sha256.Sum256(wireKey)
+		fpBuf := make([]byte, base64.StdEncoding.EncodedLen(sha256.Size))
+		base64.StdEncoding.Encode(fpBuf, sum[:])
+		if got, want := string(fpBuf), getFingerprint(sshPub); got != want {
+			t.Errorf("fingerprint hot path %q != slow path %q", got, want)
+		}
+	}
+}
+
+func TestResetCounters(t *testing.T) {
+	// Not parallel: modifies global counter state.
+
+	globalCounter.Add(100)
+	matchCounter.Add(10)
+	t.Cleanup(func() { ResetCounters() })
+
+	ResetCounters()
+
+	if got := KeyCount(); got != 0 {
+		t.Errorf("KeyCount() = %d, want 0", got)
+	}
+	if got := MatchCount(); got != 0 {
+		t.Errorf("MatchCount() = %d, want 0", got)
+	}
+}
+
+func TestFindKeys_NilRegex(t *testing.T) {
 	results := make(chan Result, 1)
-
-	go func() {
-		_ = FindKeys(ctx, Options{Regex: re}, results)
-	}()
-
+	err := FindKeys(context.Background(), Options{Regex: nil}, results)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !errors.Is(err, ErrNilRegex) {
+		t.Errorf("error = %v, want %v", err, ErrNilRegex)
+	}
 	select {
 	case r := <-results:
-		cancel()
-		if len(r.PrivateKeyPEM) == 0 {
-			t.Error("PrivateKeyPEM is empty")
-		}
-		if !strings.HasPrefix(r.AuthorizedKey, "ssh-ed25519 ") {
-			t.Errorf("AuthorizedKey = %q, want prefix %q", r.AuthorizedKey, "ssh-ed25519 ")
-		}
-		if r.Fingerprint == "" {
-			t.Error("Fingerprint is empty")
-		}
-		if len(r.Fingerprint) != 44 {
-			t.Errorf("Fingerprint length = %d, want 44", len(r.Fingerprint))
-		}
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for match")
+		t.Errorf("unexpected result: %+v", r)
+	default:
 	}
 }
 
-func TestFindKeysMatchesFingerprint(t *testing.T) {
+func TestFindKeys_Cancellation(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	// Match any fingerprint
 	re := regexp.MustCompile(`.`)
 	results := make(chan Result, 1)
-
-	go func() {
-		_ = FindKeys(ctx, Options{Regex: re, Fingerprint: true}, results)
-	}()
-
-	select {
-	case r := <-results:
-		cancel()
-		if r.Fingerprint == "" {
-			t.Error("Fingerprint is empty")
-		}
-		if len(r.PrivateKeyPEM) == 0 {
-			t.Error("PrivateKeyPEM is empty")
-		}
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for match")
-	}
-}
-
-func TestFindKeysCancellation(t *testing.T) {
-	t.Parallel()
-
-	// Impossible pattern — will never match
-	re := regexp.MustCompile(`^IMPOSSIBLE_PATTERN_THAT_NEVER_MATCHES$`)
-	results := make(chan Result, 1)
-
 	ctx, cancel := context.WithCancel(context.Background())
 
-	done := make(chan error, 1)
+	errCh := make(chan error, 1)
 	go func() {
-		done <- FindKeys(ctx, Options{Regex: re}, results)
+		errCh <- FindKeys(ctx, Options{Regex: re}, results)
 	}()
 
-	// Let it run briefly, then cancel
-	time.Sleep(50 * time.Millisecond)
+	// Wait for at least one result to prove the worker was running.
+	select {
+	case <-results:
+	case <-time.After(10 * time.Second):
+		t.Fatal("no result before cancellation")
+	}
+
 	cancel()
 
 	select {
-	case err := <-done:
+	case err := <-errCh:
 		if err != nil {
-			t.Errorf("FindKeys returned error on cancel: %v", err)
+			t.Errorf("FindKeys error on cancel: %v", err)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("FindKeys did not return after context cancellation")
+		t.Fatal("FindKeys did not return after cancel")
 	}
 }
 
-func TestFindKeysCounterIncrement(t *testing.T) {
+func TestFindKeys_AlreadyCancelledContext(t *testing.T) {
 	t.Parallel()
 
+	re := regexp.MustCompile(`^IMPOSSIBLE$`)
+	results := make(chan Result, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- FindKeys(ctx, Options{Regex: re}, results)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("did not return promptly")
+	}
+}
+
+func TestFindKeys_MultipleMatches(t *testing.T) {
+	t.Parallel()
+
+	re := regexp.MustCompile(`ssh-ed25519`)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	re := regexp.MustCompile(`ssh-ed25519`)
-	results := make(chan Result, 1)
-
+	results := make(chan Result, 3)
+	errCh := make(chan error, 1)
 	go func() {
-		_ = FindKeys(ctx, Options{Regex: re}, results)
+		errCh <- FindKeys(ctx, Options{Regex: re}, results)
+	}()
+
+	const want = 3
+	seen := make(map[string]bool)
+	for i := range want {
+		select {
+		case r := <-results:
+			if r.AuthorizedKey == "" {
+				t.Fatalf("match %d: empty AuthorizedKey", i+1)
+			}
+			seen[r.AuthorizedKey] = true
+		case <-ctx.Done():
+			t.Fatalf("timed out after %d matches", i)
+		}
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("FindKeys error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("FindKeys did not return after cancel")
+	}
+
+	if len(seen) != want {
+		t.Errorf("got %d distinct keys, want %d", len(seen), want)
+	}
+}
+
+func TestFindKeys_BlockedSendCancellation(t *testing.T) {
+	t.Parallel()
+
+	results := make(chan Result) // unbuffered — send will block
+	re := regexp.MustCompile(`ssh-ed25519`)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- FindKeys(ctx, Options{Regex: re}, results)
 	}()
 
 	select {
 	case <-results:
-		cancel()
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for match")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for first result")
 	}
 
-	if KeyCount() == 0 {
-		t.Error("KeyCount() = 0 after finding a match")
+	// Give the worker time to attempt the next blocked send.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("error on blocked-send cancel: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("did not return after cancel")
 	}
-	if MatchCount() == 0 {
-		t.Error("MatchCount() = 0 after finding a match")
+}
+
+func TestFindKeys_TrulySelectiveRegex(t *testing.T) {
+	// Not parallel: depends on and resets global counter state.
+
+	tests := []struct {
+		name        string
+		fingerprint bool
+		checkField  func(Result) string
+	}{
+		{
+			name:        "public key mode",
+			fingerprint: false,
+			checkField:  func(r Result) string { return r.AuthorizedKey },
+		},
+		{
+			name:        "fingerprint mode",
+			fingerprint: true,
+			checkField:  func(r Result) string { return r.Fingerprint },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetCounters()
+			t.Cleanup(func() { ResetCounters() })
+
+			re := regexp.MustCompile(`ZZ`)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			results := make(chan Result, 1)
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- FindKeys(ctx, Options{Regex: re, Fingerprint: tt.fingerprint}, results)
+			}()
+
+			select {
+			case r := <-results:
+				cancel()
+				if err := <-errCh; err != nil {
+					t.Fatalf("FindKeys error: %v", err)
+				}
+				if !re.MatchString(tt.checkField(r)) {
+					t.Errorf("result does not match regex: %q", tt.checkField(r))
+				}
+				assertResultFields(t, r)
+
+				if matches := MatchCount(); matches < 1 {
+					t.Errorf("MatchCount() = %d, want >= 1", matches)
+				}
+				if keys, matches := KeyCount(), MatchCount(); keys <= matches {
+					t.Errorf("KeyCount() = %d <= MatchCount() = %d; regex did not reject any keys", keys, matches)
+				}
+			case <-ctx.Done():
+				t.Fatal("timed out")
+			}
+		})
+	}
+}
+
+func TestFindKeys_FingerprintModeRejectsPubKeyPattern(t *testing.T) {
+	// Not parallel: verifies keys were generated via global counter.
+
+	ResetCounters()
+	t.Cleanup(func() { ResetCounters() })
+
+	// This regex matches every authorized key but can never match a fingerprint.
+	re := regexp.MustCompile(`^ssh-ed25519 `)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	results := make(chan Result, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- FindKeys(ctx, Options{Regex: re, Fingerprint: true}, results)
+	}()
+
+	deadline := time.After(10 * time.Second)
+	for KeyCount() < 1024 {
+		select {
+		case r := <-results:
+			t.Fatalf("fingerprint mode matched pubkey-only pattern: %+v", r)
+		case <-deadline:
+			t.Fatalf("KeyCount() = %d, want >= 1024", KeyCount())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Errorf("FindKeys error: %v", err)
+	}
+}
+
+func TestFindKeys_ConcurrentWorkers(t *testing.T) {
+	t.Parallel()
+
+	const numWorkers = 8
+	const matchesWanted = 4
+
+	re := regexp.MustCompile(`ssh-ed25519`)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	results := make(chan Result, matchesWanted)
+	errCh := make(chan error, numWorkers)
+	for range numWorkers {
+		go func() {
+			errCh <- FindKeys(ctx, Options{Regex: re}, results)
+		}()
+	}
+
+	seen := make(map[string]bool)
+	for range matchesWanted {
+		select {
+		case r := <-results:
+			seen[r.AuthorizedKey] = true
+			assertResultFields(t, r)
+		case <-ctx.Done():
+			t.Fatalf("timed out after %d/%d results", len(seen), matchesWanted)
+		}
+	}
+	cancel()
+
+	for range numWorkers {
+		if err := <-errCh; err != nil {
+			t.Errorf("FindKeys error: %v", err)
+		}
+	}
+
+	if len(seen) != matchesWanted {
+		t.Errorf("got %d distinct keys, want %d", len(seen), matchesWanted)
 	}
 }


### PR DESCRIPTION
## Summary

- Fix data races, mutex gaps, ANSI leaks, negative number formatting, and nil-regex panic across display/keygen/cmd
- Add comprehensive test suites for all three packages (cmd was previously untested)
- Tests focus on our code, not stdlib — no sign+verify round-trips or base64 cross-checks

## Release

Tag `v0.1.0` after merge.

## Test plan

- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)