### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-02-16
+
+### Added
+
+- Cobra CLI rewrite with `--fingerprint`, `--continuous`, `--jobs` flags
+- Context-based goroutine lifecycle with `errgroup` for clean shutdown
+- `keygen.Result` type — `FindKeys` is now a pure worker sending results via channel
+- Error handling for all key generation operations (no silent suppression)
+- Pinned terminal status bar with scroll region for TTY output
+- SHA256 fingerprint display on match
+- Homebrew tap via GoReleaser (`brew install sensiblebit/tap/vanityssh`)
+- GoReleaser-based release automation (darwin/linux/windows, amd64/arm64)
+- CI pipeline with reusable workflows (go-ci, pr-conventions, lint)
+- Pre-commit hooks (branch naming, commit messages, go-vet, go-build, go-test)
+- Dependabot for GitHub Actions and Go module updates
+- Makefile with build, test, vet targets
+- Export `ErrNilRegex` sentinel error for programmatic nil-regex detection
+  via `errors.Is`
+- CHANGELOG.md
+
 ### Fixed
 
 - Fix data race on `isTTY` flag by converting to `atomic.Bool`
@@ -18,33 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return `ErrNilRegex` from `FindKeys` instead of panicking on nil regex
 - Fix `OverrideTTY` data race on `termHeight` (CC-3: missing mutex)
 - Fix `--continuous` in TTY mode silently discarding matched keys
-
-### Tests
-
-- Add `cmd` test suite: CLI validation, `handleResult` file writing and
-  permissions, TTY/non-TTY output paths, write-error propagation, flag
-  wiring, end-to-end pipeline
-- Add `display` TTY-mode tests, concurrency stress tests, and edge cases
-- Add `keygen` tests: cancellation, blocked-send, selective regex, concurrent
-  workers, hot-path/slow-path equivalence, fingerprint-mode isolation
-
-### Added
-
-- Context-based goroutine lifecycle with `errgroup` for clean shutdown
-- `keygen.Result` type — `FindKeys` is now a pure worker sending results via channel
-- Error handling for all key generation operations (no silent suppression)
-- Homebrew tap via GoReleaser (`brew install sensiblebit/tap/vanityssh`)
-- Cobra CLI rewrite with `--fingerprint`, `--continuous`, `--jobs` flags
-- Pinned terminal status bar with scroll region for TTY output
-- SHA256 fingerprint display on match
-- GoReleaser-based release automation (darwin/linux/windows, amd64/arm64)
-- CI pipeline with reusable workflows (go-ci, pr-conventions, lint)
-- Pre-commit hooks (branch naming, commit messages, go-vet, go-build, go-test)
-- Dependabot for GitHub Actions and Go module updates
-- Makefile with build, test, vet targets
-- Export `ErrNilRegex` sentinel error for programmatic nil-regex detection
-  via `errors.Is`
-- CHANGELOG.md
 
 ### Changed
 
@@ -58,3 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Seven external dependencies ejected during Cobra rewrite
 - Old CI workflows (build-go.yml, create-release-tag.yaml, release-artefacts.yaml)
 - `build-cmds.txt` (replaced by Makefile)
+
+### Tests
+
+- Add `cmd` test suite: CLI validation, `handleResult` file writing and
+  permissions, TTY/non-TTY output paths, write-error propagation, flag
+  wiring, end-to-end pipeline
+- Add `display` TTY-mode tests, concurrency stress tests, and edge cases
+- Add `keygen` tests: cancellation, blocked-send, selective regex, concurrent
+  workers, hot-path/slow-path equivalence, fingerprint-mode isolation


### PR DESCRIPTION
## Summary

- Move all unreleased changelog entries to `[0.1.0] - 2026-02-16`
- Reorder sections to follow Keep a Changelog convention (Added, Fixed, Changed, Removed, Tests)

## Post-merge

After merging, tag the release:

```sh
git checkout main && git pull
git tag v0.1.0
git push origin v0.1.0
```

This will trigger GoReleaser to build and publish artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)